### PR TITLE
New rule: 301 - Contents of player file

### DIFF
--- a/mutable_rules/301_Contents-of-player-file.md
+++ b/mutable_rules/301_Contents-of-player-file.md
@@ -1,0 +1,3 @@
+Each player file shall contain no more than 100 lines, with newlines every no more than 80 characters.
+
+Any line that contains anything but the current numeric score of the player must start with a # character.


### PR DESCRIPTION
Since there are currently no restrictions on player files except that they contain the current score of the player (and their naming format), I've decided that some order might be in order.