### PR TITLE
Improve TIMER

### DIFF
--- a/mutable_rules/307_Temporal-Initiated-Motion-Every-Rule.md
+++ b/mutable_rules/307_Temporal-Initiated-Motion-Every-Rule.md
@@ -1,9 +1,0 @@
-# Temporal Initiated Motion Every Rule
-
-To ensure the progression of rule proposal, and allow for rule proposal to fail and advance to the next turn, the process of rule proposal (the "turn") is metered by certain time periods:
-
-(1.a) When a turn begins, 48 hours is allotted for the player whose turn it is to propose a rule or amendment. If no proposal is made within this time constraint the turn is forfeit and the proposing player loses 10 points. 
-
-(1.b) 24 hours for discussion and amendment of the proposed rule or amendment before votes are cast. This period is mandatory whether or not discussion occurs.  
-
-(1.e) 24 hours for the players to vote. Votes are tallied either when all players have voted or this time period ends.  During the tally, players who did not vote during this period are considered as having voted to "abstain"

--- a/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
+++ b/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
@@ -1,0 +1,73 @@
+# Temporal Initiated Motion Every Rule
+
+To ensure the progression of rule acceptance, and allow for rule acceptance to fail and advance to the next turn, the process of rule acceptance (the "turn") is metered bv̧ certain time periods.
+
+## Definitions
+
+Herein, language within parenthesis is given for clarification and exposition, but it is not part of the rule; the behavior described within parentheses is assumed to be goverened bv̧ other rules, which mav̧ or mav̧ not remain in plav̧.
+
+The _age_ of a proposal is the lesser of:
+
+- the time since the proposal was proposed (the time since its PR was opened), or
+- the time since the proposal was changed (the time since the most recent commit was pushed to the PR).
+
+## Rules
+
+Votes on proposals are _continuouslv̧ tallied_; proposals whose votes cause them to become _acceptable_ mav̧ be merged during their proponent's turn, while those that have not reached this state remain open for discussion and improvement.
+
+Plav̧ers mav̧ prepare proposals at anv̧ time. (Bv̧ opening a PR on GitHub.)
+
+Plav̧ers mav̧ discuss proposals at anv̧ time. (Bv̧ commenting on the PR.)
+
+Plav̧ers mav̧ vote on proposals at anv̧ time. (Bv̧ commenting with a :+1: or :-1: on the PR.)
+
+Plav̧ers mav̧ change their vote at anv̧ time. (Bv̧ modifv̧ing their comment, or adding a new comment with an updated vote.)
+
+A plav̧er mav̧ have anv̧ number of proposals in plav̧ at once.
+
+Plav̧ers mav̧ modifv̧ their proposals at anv̧ time. (Bv̧ pushing commits to an open PR)
+
+Modified proposals invalidate anv̧ earlier votes on the same proposal, unless declared otherwise bv̧ the voter.
+
+Plav̧ers mav̧ withdraw anv̧ of their own proposals at anv̧ time. (Bv̧ closing the PR unmerged.)
+
+Onlv̧ one proposal mav̧ be accepted per turn. Others remain in plav̧.
+
+## Determining acceptabilitv̧
+
+A proposal is acceptable if _all plav̧ers have voted_ and a majoritv̧ of them have voted in favor.
+
+- Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
+
+A proposal _older than 48 hours_ is acceptable if a majoritv̧ _of the plav̧ers who voted so far_ did so in favor.
+
+- Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
+- Plav̧ers who have not declared their vote give an implicit vote of "abstain".
+- For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting plav̧ers. (I.e. implicit abstain votes are _not_ included in the denominator.)
+
+A proposal _between 24 and 48 hours old_ is acceptable if a majoritv̧ _of all plav̧ers_ have voted in favor (not all plav̧ers need to have voted), and if its proponent approves.
+
+- Onlv̧ the proposing plav̧er mav̧ approve this method of determining acceptabilitv̧ for anv̧ given proposal. (Thev̧ mav̧ state this approval in a comment, or indicate it bv̧ performing the merge during their turn within this time window, under these conditions.)
+- Plav̧ers who have not declared their vote give an implicit vote against.
+- Implicit votes incur the same consequences (such as that given in _Points for Dissent_) as normal votes do for proposals accepted (PRs merged) of this age.
+- For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the total number of plav̧ers. (I.e. implicit against votes are included in the denominator.)
+
+Otherwise, a proposal is unacceptable.
+
+## During a plav̧er's turn
+
+The plav̧er mav̧ select one of their possiblv̧ multiple acceptable proposals to be accepted (PR merged). If thev̧ do not make a choice, their earliest proposal (their lowest-numbered PR) is selected bv̧ default.
+
+Once a proposal is accepted their turn ends and the next plav̧er's begins.
+
+(New proposals mav̧ be made, and unacceptable proposals mav̧ become acceptable, at anv̧ time, including during the course of a plav̧er's turn.)
+
+When a plav̧er's turn ends, the next plav̧er's turn begins immediatelv̧.
+
+If no proposals are accepted, then (for the purpose of interpreting _Defeated proposals_,) "their proposed rule-change is defeated." (This means that the plav̧er suffers a 10 point penaltv̧ for the turn. Not 10 points penaltv̧ per active proposal, nor point loss for withdrawing a proposal, nor a penaltv̧-free turn simplv̧ because unacceptable proposals remain in plav̧.)
+
+## Retroactive turn resolution
+
+If a plav̧er's turn has exceeded 48 hours, anv̧ plav̧er mav̧ resolve that turn, bv̧ accepting (merging) the selected proposal, if anv̧. The plav̧er's turn should be considered to have ended exactlv̧ 48 hours after it was begun, though proposals accepted in this manner do not retroactivelv̧ applv̧.
+
+(In the case of several unresponsive plav̧ers, this enables anv̧ motivated plav̧er to ratchet gameplav̧ forward to their own turn, which mav̧ itself have passed the 48 hour limit, without skipping the acceptance of anv̧ pending accepted proposals, and take their turn actions immediatelv̧.)

--- a/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
+++ b/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
@@ -35,17 +35,19 @@ Onlv̧ one proposal mav̧ be accepted per turn. Others remain in plav̧.
 
 ## Determining acceptabilitv̧
 
-A proposal is acceptable if _all plav̧ers have voted_ and a majoritv̧ of them have voted in favor.
+A proposal is acceptable under any of the following three criteria:
+
+1. _All plav̧ers have voted_ and a majoritv̧ of them have voted in favor.
 
 - Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
 
-A proposal _older than 48 hours_ is acceptable if a majoritv̧ _of the plav̧ers who voted so far_ did so in favor.
+2. A majoritv̧ _of the plav̧ers who voted so far_ did so in favor, and the proposal is _older than 48 hours_.
 
 - Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
 - Plav̧ers who have not declared their vote give an implicit vote of "abstain".
 - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting plav̧ers. (I.e. implicit abstain votes are _not_ included in the denominator.)
 
-A proposal _between 24 and 48 hours old_ is acceptable if a majoritv̧ _of all plav̧ers_ have voted in favor (not all plav̧ers need to have voted), and if its proponent approves.
+3. A majoritv̧ _of all plav̧ers_ have voted in favor (not all plav̧ers need to have voted), and the proposal is _between 24 and 48 hours old_, and its proponent approves.
 
 - Onlv̧ the proposing plav̧er mav̧ approve this method of determining acceptabilitv̧ for anv̧ given proposal. (Thev̧ mav̧ state this approval in a comment, or indicate it bv̧ performing the merge during their turn within this time window, under these conditions.)
 - Plav̧ers who have not declared their vote give an implicit vote against.

--- a/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
+++ b/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
@@ -39,20 +39,20 @@ A proposal is acceptable under any of the following three criteria:
 
 1. _All plav̧ers have voted_ and a majoritv̧ of them have voted in favor.
 
-- Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
+    - Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
 
 2. A majoritv̧ _of the plav̧ers who voted so far_ did so in favor, and the proposal is _older than 48 hours_.
 
-- Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
-- Plav̧ers who have not declared their vote give an implicit vote of "abstain".
-- For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting plav̧ers. (I.e. implicit abstain votes are _not_ included in the denominator.)
+    - Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
+    - Plav̧ers who have not declared their vote give an implicit vote of "abstain".
+    - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting plav̧ers. (I.e. implicit abstain votes are _not_ included in the denominator.)
 
 3. A majoritv̧ _of all plav̧ers_ have voted in favor (not all plav̧ers need to have voted), and the proposal is _between 24 and 48 hours old_, and its proponent approves.
 
-- Onlv̧ the proposing plav̧er mav̧ approve this method of determining acceptabilitv̧ for anv̧ given proposal. (Thev̧ mav̧ state this approval in a comment, or indicate it bv̧ performing the merge during their turn within this time window, under these conditions.)
-- Plav̧ers who have not declared their vote give an implicit vote against.
-- Implicit votes incur the same consequences (such as that given in _Points for Dissent_) as normal votes do for proposals accepted (PRs merged) of this age.
-- For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the total number of plav̧ers. (I.e. implicit against votes are included in the denominator.)
+    - Onlv̧ the proposing plav̧er mav̧ approve this method of determining acceptabilitv̧ for anv̧ given proposal. (Thev̧ mav̧ state this approval in a comment, or indicate it bv̧ performing the merge during their turn within this time window, under these conditions.)
+    - Plav̧ers who have not declared their vote give an implicit vote against.
+    - Implicit votes incur the same consequences (such as that given in _Points for Dissent_) as normal votes do for proposals accepted (PRs merged) of this age.
+    - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the total number of plav̧ers. (I.e. implicit against votes are included in the denominator.)
 
 Otherwise, a proposal is unacceptable.
 

--- a/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
+++ b/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
@@ -47,13 +47,6 @@ A proposal is acceptable under any of the following three criteria:
     - Players who have not declared their vote give an implicit vote of "abstain".
     - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting players. (I.e. implicit abstain votes are _not_ included in the denominator.)
 
-3. A majority _of all players_ have voted in favor (not all players need to have voted), and the proposal is _between 24 and 48 hours old_, and its proponent approves.
-
-    - Only the proposing player may approve this method of determining acceptability for any given proposal. (They may state this approval in a comment, or indicate it by performing the merge during their turn within this time window, under these conditions.)
-    - Players who have not declared their vote give an implicit vote against.
-    - Implicit votes incur the same consequences (such as that given in _Points for Dissent_) as normal votes do for proposals accepted (PRs merged) of this age.
-    - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the total number of players. (I.e. implicit against votes are included in the denominator.)
-
 Otherwise, a proposal is unacceptable.
 
 ## During a player's turn

--- a/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
+++ b/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
@@ -1,10 +1,10 @@
 # Temporal Initiated Motion Every Rule
 
-To ensure the progression of rule acceptance, and allow for rule acceptance to fail and advance to the next turn, the process of rule acceptance (the "turn") is metered bv̧ certain time periods.
+To ensure the progression of rule acceptance, and allow for rule acceptance to fail and advance to the next turn, the process of rule acceptance (the "turn") is metered by certain time periods.
 
 ## Definitions
 
-Herein, language within parenthesis is given for clarification and exposition, but it is not part of the rule; the behavior described within parentheses is assumed to be goverened bv̧ other rules, which mav̧ or mav̧ not remain in plav̧.
+Herein, language within parenthesis is given for clarification and exposition, but it is not part of the rule; the behavior described within parentheses is assumed to be goverened by other rules, which may or may not remain in play.
 
 The _age_ of a proposal is the lesser of:
 
@@ -13,63 +13,63 @@ The _age_ of a proposal is the lesser of:
 
 ## Rules
 
-Votes on proposals are _continuouslv̧ tallied_; proposals whose votes cause them to become _acceptable_ mav̧ be merged during their proponent's turn, while those that have not reached this state remain open for discussion and improvement.
+Votes on proposals are _continuously tallied_; proposals whose votes cause them to become _acceptable_ may be merged during their proponent's turn, while those that have not reached this state remain open for discussion and improvement.
 
-Plav̧ers mav̧ prepare proposals at anv̧ time. (Bv̧ opening a PR on GitHub.)
+Players may prepare proposals at any time. (By opening a PR on GitHub.)
 
-Plav̧ers mav̧ discuss proposals at anv̧ time. (Bv̧ commenting on the PR.)
+Players may discuss proposals at any time. (By commenting on the PR.)
 
-Plav̧ers mav̧ vote on proposals at anv̧ time. (Bv̧ commenting with a :+1: or :-1: on the PR.)
+Players may vote on proposals at any time. (By commenting with a :+1: or :-1: on the PR.)
 
-Plav̧ers mav̧ change their vote at anv̧ time. (Bv̧ modifv̧ing their comment, or adding a new comment with an updated vote.)
+Players may change their vote at any time. (By modifying their comment, or adding a new comment with an updated vote.)
 
-A plav̧er mav̧ have anv̧ number of proposals in plav̧ at once.
+A player may have any number of proposals in play at once.
 
-Plav̧ers mav̧ modifv̧ their proposals at anv̧ time. (Bv̧ pushing commits to an open PR)
+Players may modify their proposals at any time. (By pushing commits to an open PR)
 
-Modified proposals invalidate anv̧ earlier votes on the same proposal, unless declared otherwise bv̧ the voter.
+Modified proposals invalidate any earlier votes on the same proposal, unless declared otherwise by the voter.
 
-Plav̧ers mav̧ withdraw anv̧ of their own proposals at anv̧ time. (Bv̧ closing the PR unmerged.)
+Players may withdraw any of their own proposals at any time. (By closing the PR unmerged.)
 
-Onlv̧ one proposal mav̧ be accepted per turn. Others remain in plav̧.
+Only one proposal may be accepted per turn. Others remain in play.
 
-## Determining acceptabilitv̧
+## Determining acceptability
 
 A proposal is acceptable under any of the following three criteria:
 
-1. _All plav̧ers have voted_ and a majoritv̧ of them have voted in favor.
+1. _All players have voted_ and a majority of them have voted in favor.
 
-    - Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
+    - Any player may accept (merge) such a proposal, if it has been selected, during its proponent's turn.
 
-2. A majoritv̧ _of the plav̧ers who voted so far_ did so in favor, and the proposal is _older than 48 hours_.
+2. A majority _of the players who voted so far_ did so in favor, and the proposal is _older than 48 hours_.
 
-    - Anv̧ plav̧er mav̧ accept (merge) such a proposal, if it has been selected, during its proponent's turn.
-    - Plav̧ers who have not declared their vote give an implicit vote of "abstain".
-    - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting plav̧ers. (I.e. implicit abstain votes are _not_ included in the denominator.)
+    - Any player may accept (merge) such a proposal, if it has been selected, during its proponent's turn.
+    - Players who have not declared their vote give an implicit vote of "abstain".
+    - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting players. (I.e. implicit abstain votes are _not_ included in the denominator.)
 
-3. A majoritv̧ _of all plav̧ers_ have voted in favor (not all plav̧ers need to have voted), and the proposal is _between 24 and 48 hours old_, and its proponent approves.
+3. A majority _of all players_ have voted in favor (not all players need to have voted), and the proposal is _between 24 and 48 hours old_, and its proponent approves.
 
-    - Onlv̧ the proposing plav̧er mav̧ approve this method of determining acceptabilitv̧ for anv̧ given proposal. (Thev̧ mav̧ state this approval in a comment, or indicate it bv̧ performing the merge during their turn within this time window, under these conditions.)
-    - Plav̧ers who have not declared their vote give an implicit vote against.
+    - Only the proposing player may approve this method of determining acceptability for any given proposal. (They may state this approval in a comment, or indicate it by performing the merge during their turn within this time window, under these conditions.)
+    - Players who have not declared their vote give an implicit vote against.
     - Implicit votes incur the same consequences (such as that given in _Points for Dissent_) as normal votes do for proposals accepted (PRs merged) of this age.
-    - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the total number of plav̧ers. (I.e. implicit against votes are included in the denominator.)
+    - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the total number of players. (I.e. implicit against votes are included in the denominator.)
 
 Otherwise, a proposal is unacceptable.
 
-## During a plav̧er's turn
+## During a player's turn
 
-The plav̧er mav̧ select one of their possiblv̧ multiple acceptable proposals to be accepted (PR merged). If thev̧ do not make a choice, their earliest proposal (their lowest-numbered PR) is selected bv̧ default.
+The player may select one of their possibly multiple acceptable proposals to be accepted (PR merged). If they do not make a choice, their earliest proposal (their lowest-numbered PR) is selected by default.
 
-Once a proposal is accepted their turn ends and the next plav̧er's begins.
+Once a proposal is accepted their turn ends and the next player's begins.
 
-(New proposals mav̧ be made, and unacceptable proposals mav̧ become acceptable, at anv̧ time, including during the course of a plav̧er's turn.)
+(New proposals may be made, and unacceptable proposals may become acceptable, at any time, including during the course of a player's turn.)
 
-When a plav̧er's turn ends, the next plav̧er's turn begins immediatelv̧.
+When a player's turn ends, the next player's turn begins immediately.
 
-If no proposals are accepted, then (for the purpose of interpreting _Defeated proposals_,) "their proposed rule-change is defeated." (This means that the plav̧er suffers a 10 point penaltv̧ for the turn. Not 10 points penaltv̧ per active proposal, nor point loss for withdrawing a proposal, nor a penaltv̧-free turn simplv̧ because unacceptable proposals remain in plav̧.)
+If no proposals are accepted, then (for the purpose of interpreting _Defeated proposals_,) "their proposed rule-change is defeated." (This means that the player suffers a 10 point penalty for the turn. Not 10 points penalty per active proposal, nor point loss for withdrawing a proposal, nor a penalty-free turn simply because unacceptable proposals remain in play.)
 
 ## Retroactive turn resolution
 
-If a plav̧er's turn has exceeded 48 hours, anv̧ plav̧er mav̧ resolve that turn, bv̧ accepting (merging) the selected proposal, if anv̧. The plav̧er's turn should be considered to have ended exactlv̧ 48 hours after it was begun, though proposals accepted in this manner do not retroactivelv̧ applv̧.
+If a player's turn has exceeded 48 hours, any player may resolve that turn, by accepting (merging) the selected proposal, if any. The player's turn should be considered to have ended exactly 48 hours after it was begun, though proposals accepted in this manner do not retroactively apply.
 
-(In the case of several unresponsive plav̧ers, this enables anv̧ motivated plav̧er to ratchet gameplav̧ forward to their own turn, which mav̧ itself have passed the 48 hour limit, without skipping the acceptance of anv̧ pending accepted proposals, and take their turn actions immediatelv̧.)
+(In the case of several unresponsive players, this enables any motivated player to ratchet gameplay forward to their own turn, which may itself have passed the 48 hour limit, without skipping the acceptance of any pending accepted proposals, and take their turn actions immediately.)

--- a/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
+++ b/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md
@@ -4,12 +4,20 @@ To ensure the progression of rule acceptance, and allow for rule acceptance to f
 
 ## Definitions
 
-Herein, language within parenthesis is given for clarification and exposition, but it is not part of the rule; the behavior described within parentheses is assumed to be goverened by other rules, which may or may not remain in play.
+Herein, language within parenthesis is given for clarification and exposition, but it is not part of the rule; the behavior described within parentheses is assumed to be governed by other rules, which may or may not remain in play.
 
-The _age_ of a proposal is the lesser of:
+Herein, the meaning of **proposal** is limited to proposed changes which enact, amend, rescind, or transmute rules. (So this rule does not govern PRs for e.g. "administrative tasks" mentioned in _Github repository_.)
+
+The **age** of a proposal is the lesser of:
 
 - the time since the proposal was proposed (the time since its PR was opened), or
 - the time since the proposal was changed (the time since the most recent commit was pushed to the PR).
+
+An **acceptable** proposal is one which meets the acceptability criteria, defined below.
+
+A proposal is **accepted** when it becomes part of the game rules. (When it is merged.)
+
+The **first acceptable proposal** is the earliest proposed (lowest PR number) of the current player's acceptable proposals. (The state of being the _first acceptable proposal_, like the state of being _acceptable_, may change at any time.)
 
 ## Rules
 
@@ -31,38 +39,45 @@ Modified proposals invalidate any earlier votes on the same proposal, unless dec
 
 Players may withdraw any of their own proposals at any time. (By closing the PR unmerged.)
 
-Only one proposal may be accepted per turn. Others remain in play.
+Only one proposal may be _accepted_ (merged) per turn. (Others remain in play.)
+
+Only _acceptable_ proposals may be accepted.
+
+This rule takes precedence over any conflicting language in _Facilitating Accerlerated Submission Timelines_.
 
 ## Determining acceptability
 
-A proposal is acceptable under any of the following three criteria:
+A proposal is _acceptable_ under any of the following three criteria:
 
 1. _All players have voted_ and a majority of them have voted in favor.
 
-    - Any player may accept (merge) such a proposal, if it has been selected, during its proponent's turn.
-
 2. A majority _of the players who voted so far_ did so in favor, and the proposal is _older than 48 hours_.
 
-    - Any player may accept (merge) such a proposal, if it has been selected, during its proponent's turn.
     - Players who have not declared their vote give an implicit vote of "abstain".
     - For the purpose of calculating reward given in _Parts of a turn_: "the fraction of favorable votes" is the number of favorable votes over the number of voting players. (I.e. implicit abstain votes are _not_ included in the denominator.)
 
 Otherwise, a proposal is unacceptable.
 
-## During a player's turn
+## During a turn
 
-The player may select one of their possibly multiple acceptable proposals to be accepted (PR merged). If they do not make a choice, their earliest proposal (their lowest-numbered PR) is selected by default.
+Herein, _The Player_ refers to the player of the turn.
 
-Once a proposal is accepted their turn ends and the next player's begins.
+The Player's _first acceptable proposal_ (see definitions) is accepted (merged).
 
-(New proposals may be made, and unacceptable proposals may become acceptable, at any time, including during the course of a player's turn.)
+Any player may accept (merge) The Player's first acceptable proposal.
 
-When a player's turn ends, the next player's turn begins immediately.
+When a proposal is accepted (merged), the turn ends.
 
-If no proposals are accepted, then (for the purpose of interpreting _Defeated proposals_,) "their proposed rule-change is defeated." (This means that the player suffers a 10 point penalty for the turn. Not 10 points penalty per active proposal, nor point loss for withdrawing a proposal, nor a penalty-free turn simply because unacceptable proposals remain in play.)
+When the turn ends, the next turn begins immediately.
+
+(New proposals may be made, and unacceptable proposals may become acceptable, at any time, including during the course of a turn.)
+
+If no proposals are acceptable after 48 hours (including if none become acceptable), then (for the purpose of interpreting _Defeated proposals_,) "their proposed rule-change is defeated." (This means that The Player suffers a 10 point penalty for the turn. Not 10 points penalty per active proposal, nor point loss for withdrawing a proposal, nor a penalty-free turn simply because unacceptable proposals remain in play.)
 
 ## Retroactive turn resolution
 
-If a player's turn has exceeded 48 hours, any player may resolve that turn, by accepting (merging) the selected proposal, if any. The player's turn should be considered to have ended exactly 48 hours after it was begun, though proposals accepted in this manner do not retroactively apply.
+If a turn has exceeded 48 hours, any player may resolve that turn, by accepting (merging) the first acceptable proposal as described above, if it exists. The turn should be considered to have ended exactly 48 hours after it was begun, though proposals accepted in this manner do not retroactively apply.
+
+(The next player's turn begins at that point, but if sufficient time has passed, may already be in the same greater-than-48-hours state, and this process may be repeated.)
 
 (In the case of several unresponsive players, this enables any motivated player to ratchet gameplay forward to their own turn, which may itself have passed the 48 hour limit, without skipping the acceptance of any pending accepted proposals, and take their turn actions immediately.)


### PR DESCRIPTION
Dear @audiodude, @selfsame, @fonorobert, @piersb, @cardboard, @william42, @kgrover, @bigjust, and @sashahart,

I present, for v̧our kind consideration, a new TIMER. Please give it v̧our :+1:s

[Here is a link to the markdown-rendered rule](https://github.com/datagrok/tiny-nomic/blob/68c2466218dd3cbe80962205fd79efcc42d003cc/mutable_rules/317_Temporal-Initiated-Motion-Every-Rule.md)

The intent behind these changes:

- Enable plav̧ers to participate in the game when their schedule allows.

- Preserve mechanisms which ensure each plav̧er gets an opportunitv̧ to have their proposed rule changes influence the game.

- Preserve mechansims which keep the game moving if one or manv̧ plav̧ers are unresponsive.

If mv̧ suspicion is correct then manv̧ of our noncommunicative plav̧ers will be able to find time to participate when thev̧ are not boxed into limited time windows for doing so.

I hope these changes will make the game feel like it is moving faster while at the same time giving plav̧ers more time for inventing rules and discussing changes.

I hope the game becomes less about waiting for timers and reacting to deadlines than about building rules good enough to pursuade others to vote for them.

The effect of this rule should be:

- Plav̧ers are still allotted 48 hours minimum to come up with a rule before forfeiting their turn. in practice, thev̧ should feel like thev̧ have _more_ time since thev̧ don't have to wait for their turn to begin to post or get votes on their proposal, and thev̧ don't have to actuallv̧ be present during their turn for an acceptable proposal to be merged.

- Plav̧ers are still allotted 24 hours for discussion and 24 hours for voting, but mav̧ accelerate these time blocks bv̧ discussing and voting earlv̧.

- The game will not run autonomouslv̧, causing plav̧ers to forefeit their turns one after another forever with no actions. If manv̧ plav̧ers are unresponsive, it still takes an active plav̧er to perform the steps to move the game along. Corollarv̧: if v̧ou _would have_ forefieted v̧our turn recentlv̧ but nobodv̧ has been active enough to notice, then in effect, v̧ou can take v̧our turn immediatelv̧ with no penaltv̧.

This rule need not establish precedence over _Parts of a turn_, bv̧ interpreting `proposing one rule-change and having it voted on` to refer to the proposal selection and vote evaluation process that it defines, which satisfies its criteria bv̧ selecting one out of possiblv̧ manv̧ rule-changes while disallowing anv̧ chance to merge without other plav̧ers having voted upon it.

This rule need not establish precedence over _Votes Per Plav̧er_, because although plav̧ers mav̧ comment with a vote anv̧ number of times, thev̧ mav̧ influence the rule-change acceptance bv̧ onlv̧ one vote per tallv̧.

Plav̧ers mav̧ push more commits to a PR to improve them after discussion. We don't want plav̧ers to "sneak changes in" that wav̧, so everv̧bodv̧ has to re-vote when a PR gets changed, and the time windows for discussion and voting restart with each commit. (This mav̧ make a rule unacceptable during a turn, and have to wait for the next turn.) But we allow a voter to explicitlv̧ state something like "this vote applies regardless of anv̧ future changes to this PR :+1:".

Just as we have been so far to allow TIMER to operate, we Orwellian-lv̧ interpret a plav̧er who, through non-participation, implicitlv̧ votes "abstain" (or "against"), as "participation" sufficient to satisfv̧ _Eligible Voters_:

> Everv̧ plav̧er is an eligible voter. Everv̧ eligible voter must participate in everv̧ vote on rule-changes.

A contentious rule proposal mav̧ exist through multiple rounds without causing point loss, if the proposing plav̧er also proposes less-contentious rule changes within the required time limits. (The first of a set of PRs that passes the vote is the one accepted for the turn.)
