### PR TITLE
Amend ACRONYM to allow acronyms in filenames

### DIFF
--- a/mutable_rules/302_All-Created-Rule-Orders-Now-Yield-Monikers.md
+++ b/mutable_rules/302_All-Created-Rule-Orders-Now-Yield-Monikers.md
@@ -1,5 +1,9 @@
 # All Created Rule Orders Now Yield Monikers
 
-(a) As a prequisite condition to consideration, all newly proposed rules must carry a title (referred to in this rule as "the title"), which is included in their filename and as the first line of their contents.
+(a) As a prequisite condition to consideration, all newly proposed rules must carry a title (hereafter, _the title_).
 
-(b) The first letter of each word of the title, when combined in the order of the words of the title, must itself be a word.
+(b) The title must be included as the first line of the rule file, prefixed with an octothorpe (#).
+
+(b) The first letter of each word of the title, when combined in the order of the words of the title, must itself be a word (hereafter, "acronym".)
+
+(c) Either the acronym or the title must be included in the filename.


### PR DESCRIPTION
Allows filenames to be their acronyms, not their full titles.

Also, performs that change for all rules implemented under ACRONYM.