### PR TITLE
Rescind no-op rule _Conspiracy to rule change_

### DIFF
--- a/mutable_rules/210_Conspiracy-to-rule-change.md
+++ b/mutable_rules/210_Conspiracy-to-rule-change.md
@@ -1,5 +1,0 @@
-Players may not conspire or consult on the making of future rule-changes unless
-they are team-mates.
-
-The first paragraph of this rule does not apply to games by mail or computer 
-(or, by extension, those played on Github).


### PR DESCRIPTION
This rule has no effect in this game, since it is being played on GitHub. Let's rescind it.