### PR TITLE
Add new rule, 318-FEE

### DIFF
--- a/mutable_rules/318-FEE.md
+++ b/mutable_rules/318-FEE.md
@@ -12,3 +12,6 @@ of +10 points, player B may make a pull request that gives player A 8 points and
 him or herself 2 points.
 
 In no case may a player record a fee for updating his or her own score.
+
+This rule takes precedence over all rules specifying when and how score change
+pull requests should be made.

--- a/mutable_rules/318-FEE.md
+++ b/mutable_rules/318-FEE.md
@@ -1,0 +1,14 @@
+# Fantastic Egg Everyone
+
+If a player's score requires updating, for any reason described in any of the
+other rules, then the first player to create and merge a pull request that
+updates the necessary score may be awarded 2 points. These points are known as
+the "update fee" for the score change. This fee is deducted from the score of
+the player whose score is being updated.
+
+A player is only awarded a fee if he or she records it in the same pull request
+that is updating the score. For example, if player A requires a score adjustment
+of +10 points, player B may make a pull request that gives player A 8 points and
+him or herself 2 points.
+
+In no case may a player record a fee for updating his or her own score.


### PR DESCRIPTION
I've noticed that scores are not being updated particularly consistently, and decided to add some incentive for players to update each other's scores.

Also please note in advance that the rules of ACRONYM do not require that that words constituting the acronym make any kind of sense.